### PR TITLE
Mention valid module names in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Then add `bs-jest` to `bs-dev-dependencies` in your `bsconfig.json`:
 
 ## Usage
 
-Put tests in a `__tests__` directory and use the suffix `*test.ml`/`*test.re`. When compiled they will be put in a `__tests__` directory under `lib`, with a `*test.js` suffix, ready to be picked up when you run `jest`. If you're not already familiar with [Jest](https://github.com/facebook/jest), see [the Jest documentation](https://facebook.github.io/jest/).
+Put tests in a `__tests__` directory and use the suffix `*test.ml`/`*test.re` (Make sure they are valid module names. e.g. `<name>.test.re` is not a valid module). When compiled they will be put in a `__tests__` directory under `lib`, with a `*test.js` suffix, ready to be picked up when you run `jest`. If you're not already familiar with [Jest](https://github.com/facebook/jest), see [the Jest documentation](https://facebook.github.io/jest/).
 
 ## Contribute
 ```sh

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Then add `bs-jest` to `bs-dev-dependencies` in your `bsconfig.json`:
 
 ## Usage
 
-Put tests in a `__tests__` directory and use the suffix `*test.ml`/`*test.re` (Make sure they are valid module names. e.g. `<name>.test.re` is not a valid module). When compiled they will be put in a `__tests__` directory under `lib`, with a `*test.js` suffix, ready to be picked up when you run `jest`. If you're not already familiar with [Jest](https://github.com/facebook/jest), see [the Jest documentation](https://facebook.github.io/jest/).
+Put tests in a `__tests__` directory and use the suffix `*test.ml`/`*test.re` (Make sure to use valid module names. e.g. `<name>_test.re` is valid while `<name>.test.re` is not). When compiled they will be put in a `__tests__` directory under `lib`, with a `*test.js` suffix, ready to be picked up when you run `jest`. If you're not already familiar with [Jest](https://github.com/facebook/jest), see [the Jest documentation](https://facebook.github.io/jest/).
 
 ## Contribute
 ```sh


### PR DESCRIPTION
In the JS world naming tests like this `<name>.test.js` is fairly common.

I followed the readme: 
> Put tests in a `__tests__` directory and use the suffix `*test.ml`/`*test.re`.

And created a test module called `foo.test.re` Like I usually do in JS but nothing got transpiled to JS. It took a bit of figuring out that this notation is not a valid module name in OCaml and the test module names ultimately have to adhere to https://github.com/BuckleScript/bucklescript/blob/master/jscomp/ext/ext_string.ml#L321 (which is `[a-z|A-Z|0-9|\-|\\]` in JS regex?) so bs picks them up.

I fear that other people who are equally unfamiliar with OCaml modules will get confused the same way when following the readme.

What do you think about amending the readme slightly to make this less likely to happen?